### PR TITLE
fix: Aumentato z-index per header e EyeButton in modalità fullscreen Android

### DIFF
--- a/src/components/GenericComponents/EyeButton.vue
+++ b/src/components/GenericComponents/EyeButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <button v-on:click="toggleHide($event)">
+    <button v-on:click="toggleHide($event)" class="relative z-50">
         <i v-if="hideIcon === false" class="fas fa-eye"></i>
         <i v-if="hideIcon === true" class="fas fa-eye-slash"></i>
     </button>

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="md:left-0 md:block md:fixed md:top-0 md:bottom-0 md:overflow-y-auto md:flex-row md:flex-nowrap md:overflow-hidden shadow-xl bg-white flex flex-wrap items-center justify-between relative md:w-64 z-10 py-4 px-6">
+    class="md:left-0 md:block md:fixed md:top-0 md:bottom-0 md:overflow-y-auto md:flex-row md:flex-nowrap md:overflow-hidden shadow-xl bg-white flex flex-wrap items-center justify-between relative md:w-64 z-50 py-4 px-6">
     <div
       class="md:flex-col md:items-stretch md:min-h-full md:flex-nowrap px-0 flex flex-wrap items-center justify-between w-full mx-auto">
       <!-- Toggler -->


### PR DESCRIPTION
## Descrizione
Risolve il problema dei pulsanti nell'header non cliccabili quando l'app Android è in modalità fullscreen.

## Modifiche
- Aumentato z-index della Sidebar da z-10 a z-50
- Aggiunto z-index al componente EyeButton per garantire la cliccabilità
- I pulsanti nell'header sono ora sempre sopra il contenuto a schermo intero

## Test
- Testare su Android in modalità fullscreen
- Verificare che il pulsante EyeButton sia cliccabile
- Verificare che non ci siano regressioni su altri componenti